### PR TITLE
Global coordinate control update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(fog_msgs)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
@@ -21,7 +22,8 @@ set(msg_files
 set(srv_files
   srv/Vec4.srv
   srv/Path.srv
-  srv/Point.srv
+  srv/WaypointToLocal.srv
+  srv/PathToLocal.srv
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/srv/PathToLocal.srv
+++ b/srv/PathToLocal.srv
@@ -1,0 +1,5 @@
+nav_msgs/Path path
+---
+nav_msgs/Path path
+bool success
+string message

--- a/srv/Point.srv
+++ b/srv/Point.srv
@@ -1,4 +1,0 @@
-geometry_msgs/Point goal
----
-bool success
-string message

--- a/srv/WaypointToLocal.srv
+++ b/srv/WaypointToLocal.srv
@@ -1,0 +1,9 @@
+float64 latitude_deg
+float64 longitude_deg
+float64 relative_altitude_m
+---
+float64 local_x
+float64 local_y
+float64 local_z
+bool success
+string message


### PR DESCRIPTION
This update will allow the user to use both local and global waypoints as input commands. Coordinate frame conversion is handled by the control_interface, other nodes can request global to local conversion by a service.
Corresponding changes have been made to: control_interface, fog_msgs, navigation