### PR TITLE
fix artifactory build-info

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,12 +13,10 @@ jobs:
       matrix:
         ros2_distro: [foxy, galactic]
     steps:
-
       - name: Checkout fog_msgs
         uses: actions/checkout@v2
         with:
           path: fog_msgs
-
       # Run docker build
       - name: Run fog-msgs docker build
         env:
@@ -31,11 +29,26 @@ jobs:
           pushd fog_msgs
           ./build.sh ../bin/
           popd
+      - name: Upload build
+        uses: actions/upload-artifact@v2
+        with:
+          name: fog_msgs
+          path: bin/*.deb
+          retention-days: 1
 
+  artifactory:
+    runs-on: ubuntu-latest
+    needs: tii-deb-build
+    if: github.event_name == 'push'
+    steps:
+      - name: Download builds
+        uses: actions/download-artifact@v2
+        with:
+          name: fog_msgs
+          path: bin
       - uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.ARTIFACTORY_TOKEN }}
-
       - name: Upload to Artifactory
         env:
           ARTIFACTORY_REPO: debian-public-local
@@ -48,13 +61,15 @@ jobs:
         run: |
           set -exu
           jfrog rt ping
-          pkg=$(find bin -name 'ros-${{ matrix.ros2_distro }}-fog-msgs*.deb')
-          jfrog rt u --deb "$DISTRIBUTION/$COMPONENT/$ARCHITECTURE" \
-                     --target-props COMMIT="$GITHUB_SHA" \
-                     --build-name "$BUILD_NAME" \
-                     --build-number "$GITHUB_SHA" \
-                     "$pkg" \
-                     "$ARTIFACTORY_REPO"
+          for pkg in bin/*.deb
+          do
+            jfrog rt u --deb "$DISTRIBUTION/$COMPONENT/$ARCHITECTURE" \
+                       --target-props COMMIT="$GITHUB_SHA" \
+                       --build-name "$BUILD_NAME" \
+                       --build-number "$GITHUB_SHA" \
+                       "$pkg" \
+                       "$ARTIFACTORY_REPO"
+          done
           jfrog rt build-publish "$BUILD_NAME" "$GITHUB_SHA"
           jfrog rt bpr "$BUILD_NAME" "$GITHUB_SHA" "$ARTIFACTORY_REPO" \
                        --status dev \


### PR DESCRIPTION
fog_msgs build-info was corrupted in Artifactory, because build was
published twice for both foxy and galactic debian packages.